### PR TITLE
Hide third gallery image on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -468,6 +468,10 @@ footer p {
         height: 100px;
     }
 
+    .timeline-gallery img:nth-child(3) {
+        display: none;
+    }
+
     .timeline-media {
         flex-direction: column;
     }


### PR DESCRIPTION
## Summary
- Hide the third image in history timeline galleries on mobile devices
- Desktop (>768px): Shows all 3 images per gallery row
- Mobile (<=768px): Shows only 2 images per gallery row

## Test plan
- [ ] View site on desktop - verify 3 images show in each gallery
- [ ] View site on mobile (or resize browser <768px) - verify only 2 images show

🤖 Generated with [Claude Code](https://claude.com/claude-code)