### PR TITLE
Add cache-busting version to CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="style.css?v=2">
 </head>
 <body>
     <main class="container">


### PR DESCRIPTION
## Summary
- Add version query parameter to CSS link to force browser cache refresh
- Fixes mobile gallery not showing updated styles

🤖 Generated with [Claude Code](https://claude.com/claude-code)