### PR TITLE
Show only streaming icons on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="style.css?v=5">
+    <link rel="stylesheet" href="style.css?v=6">
 </head>
 <body>
     <div class="lang-toggle">

--- a/style.css
+++ b/style.css
@@ -522,8 +522,17 @@ footer p {
     }
 
     .cta-button {
-        padding: 0.875rem 2rem;
+        padding: 1rem;
         font-size: 1rem;
+    }
+
+    .cta-button span {
+        display: none;
+    }
+
+    .cta-button svg {
+        width: 28px;
+        height: 28px;
     }
 
     .links-section {


### PR DESCRIPTION
## Summary
- Hide text labels on streaming buttons for mobile (<=768px)
- Show only platform icons for cleaner, more compact design
- Larger icons (28px) for better tap targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)