### PR TITLE
Fix mobile streaming buttons to 3-3 layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="style.css?v=9">
+    <link rel="stylesheet" href="style.css?v=10">
 </head>
 <body>
     <div class="lang-toggle">

--- a/style.css
+++ b/style.css
@@ -551,6 +551,11 @@ footer p {
         min-height: 100vh;
     }
 
+    .streaming-buttons {
+        max-width: 200px;
+        margin: 0 auto;
+    }
+
     .cta-button {
         padding: 1rem;
         font-size: 1rem;


### PR DESCRIPTION
## Summary
- Constrain streaming buttons container width on mobile
- Forces 3 icons per row instead of 4-2 layout

## Test plan
- [ ] Verify mobile view shows 3-3 button layout
- [ ] Check desktop view is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)