### PR TITLE
Fix mobile streaming buttons 3x3 grid layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="style.css?v=11">
+    <link rel="stylesheet" href="style.css?v=12">
 </head>
 <body>
     <div class="lang-toggle">

--- a/style.css
+++ b/style.css
@@ -552,13 +552,17 @@ footer p {
     }
 
     .streaming-buttons {
-        max-width: 200px;
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 0.75rem;
+        max-width: 220px;
         margin: 0 auto;
     }
 
     .cta-button {
-        padding: 1rem;
+        padding: 0.875rem;
         font-size: 1rem;
+        justify-content: center;
     }
 
     .cta-button span {


### PR DESCRIPTION
## Summary
- Use CSS grid with 3 columns for mobile streaming buttons
- Ensures proper 3-3 layout (two rows of three icons each)

## Test plan
- [ ] Verify mobile view shows 3x3 button grid
- [ ] Check desktop view is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)