### PR TITLE
Redesign favicon with simple electric guitar

### DIFF
--- a/favicon.svg
+++ b/favicon.svg
@@ -1,60 +1,28 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <!-- Electric guitar silhouette - clean and recognizable -->
-  <defs>
-    <linearGradient id="guitar" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#CD853F"/>
-      <stop offset="100%" style="stop-color:#8B4513"/>
-    </linearGradient>
-  </defs>
+  <!-- Simple electric guitar silhouette -->
 
   <!-- Headstock -->
-  <path d="M14 1 L18 1 L18 3 L19 3 L19 5 L18 5 L18 6 L14 6 L14 5 L13 5 L13 3 L14 3 Z" fill="#1a1a1a"/>
+  <rect x="14" y="1" width="4" height="4" rx="1" fill="#4693ff"/>
+
   <!-- Tuning pegs -->
-  <circle cx="12" cy="3" r="1" fill="#C0C0C0"/>
-  <circle cx="12" cy="5" r="1" fill="#C0C0C0"/>
-  <circle cx="20" cy="3" r="1" fill="#C0C0C0"/>
-  <circle cx="20" cy="5" r="1" fill="#C0C0C0"/>
+  <circle cx="12.5" cy="2.5" r="1.2" fill="#4693ff"/>
+  <circle cx="12.5" cy="4.5" r="1.2" fill="#4693ff"/>
+  <circle cx="19.5" cy="2.5" r="1.2" fill="#4693ff"/>
+  <circle cx="19.5" cy="4.5" r="1.2" fill="#4693ff"/>
 
   <!-- Neck -->
-  <rect x="14" y="6" width="4" height="10" fill="#DEB887"/>
-  <!-- Fret markers -->
-  <circle cx="16" cy="9" r="0.6" fill="#1a1a1a"/>
-  <circle cx="16" cy="13" r="0.6" fill="#1a1a1a"/>
+  <rect x="14.5" y="5" width="3" height="11" fill="#4693ff"/>
 
-  <!-- Body - Superstrat double cutaway shape -->
-  <path d="M16 15
-           C10 15 7 18 7 22
-           C7 26 10 30 16 30
-           C22 30 25 26 25 22
-           C25 18 22 15 16 15
-           Z" fill="url(#guitar)"/>
+  <!-- Body - classic electric guitar shape -->
+  <ellipse cx="16" cy="23" rx="9" ry="7" fill="#4693ff"/>
 
-  <!-- Upper horn cutaways -->
-  <path d="M10 16 Q8 15 9 18 L12 17 Z" fill="url(#guitar)"/>
-  <path d="M22 16 Q24 15 23 18 L20 17 Z" fill="url(#guitar)"/>
+  <!-- Upper cutaway (left horn) -->
+  <ellipse cx="9" cy="17" rx="3" ry="4" fill="#4693ff"/>
 
-  <!-- Pickguard -->
-  <path d="M11 20 Q10 22 11 25 L15 26 L15 19 Z" fill="#1a1a1a" opacity="0.8"/>
+  <!-- Upper cutaway (right horn) -->
+  <ellipse cx="23" cy="17" rx="3" ry="4" fill="#4693ff"/>
 
-  <!-- Pickups -->
-  <rect x="12" y="20" width="8" height="1.5" rx="0.5" fill="#2a2a2a"/>
-  <rect x="12" y="23" width="8" height="1.5" rx="0.5" fill="#2a2a2a"/>
-  <!-- Pickup poles -->
-  <circle cx="13" cy="20.75" r="0.3" fill="#C0C0C0"/>
-  <circle cx="15" cy="20.75" r="0.3" fill="#C0C0C0"/>
-  <circle cx="17" cy="20.75" r="0.3" fill="#C0C0C0"/>
-  <circle cx="19" cy="20.75" r="0.3" fill="#C0C0C0"/>
-
-  <!-- Bridge -->
-  <rect x="13" y="26" width="6" height="2" rx="0.5" fill="#C0C0C0"/>
-
-  <!-- Strings -->
-  <line x1="14" y1="6" x2="14" y2="27" stroke="#E0E0E0" stroke-width="0.3"/>
-  <line x1="15.3" y1="6" x2="15.3" y2="27" stroke="#E0E0E0" stroke-width="0.35"/>
-  <line x1="16.7" y1="6" x2="16.7" y2="27" stroke="#E0E0E0" stroke-width="0.4"/>
-  <line x1="18" y1="6" x2="18" y2="27" stroke="#E0E0E0" stroke-width="0.45"/>
-
-  <!-- Volume/Tone knobs -->
-  <circle cx="21" cy="26" r="1.3" fill="#1a1a1a"/>
-  <circle cx="21" cy="26" r="0.5" fill="#C0C0C0"/>
+  <!-- Sound hole / pickup area (dark) -->
+  <rect x="12" y="21" width="8" height="2" rx="1" fill="#0a0a0a"/>
+  <rect x="12" y="24" width="8" height="2" rx="1" fill="#0a0a0a"/>
 </svg>


### PR DESCRIPTION
## Summary
- Simplified electric guitar silhouette
- Uses site accent blue color (#4693ff)
- Clear double-cutaway body shape with horns
- Dark pickup rectangles for detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)