### PR TITLE
Add visits counter (fixes #31)

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="style.css?v=13">
+    <link rel="stylesheet" href="style.css?v=14">
 </head>
 <body>
     <div class="lang-toggle">
@@ -201,6 +201,10 @@
         </section>
 
         <footer>
+            <div class="visits-counter">
+                <span data-i18n="totalVisits">Total visits:</span>
+                <span id="visits-count" class="visits-count">...</span>
+            </div>
             <p data-i18n="copyright">&copy; 2025 Radek. All rights reserved.</p>
         </footer>
     </main>

--- a/style.css
+++ b/style.css
@@ -592,6 +592,24 @@ footer p {
     color: var(--text-muted);
 }
 
+/* Visits Counter */
+.visits-counter {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+    font-size: 0.875rem;
+    color: var(--text-muted);
+}
+
+.visits-count {
+    font-family: 'Oswald', sans-serif;
+    font-weight: 600;
+    color: var(--accent-blue);
+    letter-spacing: 0.05em;
+}
+
 /* Responsive */
 @media (max-width: 768px) {
     .hero {

--- a/translations.js
+++ b/translations.js
@@ -62,6 +62,7 @@ const translations = {
         soloDesc3: "The result: <strong>Rock Majesty</strong> and <strong>One Beautiful Day in Litomyšl</strong> — the first original compositions, marking the beginning of a new chapter.",
 
         // Footer
+        totalVisits: "Total visits:",
         copyright: "© 2025 Radek. All rights reserved."
     },
     cs: {
@@ -127,6 +128,7 @@ const translations = {
         soloDesc3: "Výsledek: <strong>Rock Majesty</strong> a <strong>One Beautiful Day in Litomyšl</strong> — první originální skladby, které znamenají začátek nové kapitoly.",
 
         // Footer
+        totalVisits: "Celkem návštěv:",
         copyright: "© 2025 Radek. Všechna práva vyhrazena."
     }
 };
@@ -185,4 +187,26 @@ function toggleLanguage(lang) {
 // Initialize on page load
 document.addEventListener('DOMContentLoaded', () => {
     applyTranslations(currentLang);
+    initVisitsCounter();
 });
+
+// Visits Counter using hits.seeyoufarm.com
+function initVisitsCounter() {
+    const counterElement = document.getElementById('visits-count');
+    if (!counterElement) return;
+
+    fetch('https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fradek.band&count_bg=%230051c3&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=visits&edge_flat=false')
+        .then(response => response.text())
+        .then(svg => {
+            const match = svg.match(/>(\d+)\s*\/\s*(\d+)</);
+            if (match) {
+                const totalCount = match[2];
+                counterElement.textContent = totalCount;
+            } else {
+                counterElement.textContent = '—';
+            }
+        })
+        .catch(() => {
+            counterElement.textContent = '—';
+        });
+}


### PR DESCRIPTION
## Summary
Implements a visits counter in the footer that displays the total number of page visits.

## Problem
Issue #31 requested adding a visits counter to track and display site visits.

## Solution
Used hits.seeyoufarm.com API - a free, reliable counter service that works with static websites. The counter:
- Increments on each page load
- Displays the total visit count in the footer
- Supports both English and Czech translations
- Styled to match the existing site design

## Changes
- `index.html` - Added visits counter element in footer, updated CSS cache version
- `translations.js` - Added counter fetch logic and translations for EN/CS
- `style.css` - Added styling for visits counter display

## Testing
- [x] Counter element displays in footer
- [x] Translations work for EN and CS languages
- [x] Styling matches site theme
- [x] Fallback display (—) for API errors

Fixes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)