### PR TITLE
Add Folded Galaxies album with Spotify pre-save

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="style.css?v=14">
+    <link rel="stylesheet" href="style.css?v=15">
 </head>
 <body>
     <div class="lang-toggle">
@@ -38,6 +38,24 @@
                             <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/>
                         </svg>
                         <span data-i18n="watchTeaser">Watch the Teaser</span>
+                    </a>
+                </div>
+
+                <div class="new-release-boxes">
+                    <div class="release-box">
+                        <img src="https://distrokid.imgix.net/http%3A%2F%2Fgather.fandalism.com%2F11039658--A232D27F-4A6E-4B06-878E23B4C72971B7--0--2057568--FoldedGalaxies.png?w=200&h=200&fit=crop" alt="Folded Galaxies" class="release-cover">
+                        <div class="release-info-box">
+                            <p class="release-label" data-i18n="newAlbum">New Album</p>
+                            <h3 class="release-title">Folded Galaxies</h3>
+                            <p class="release-date" data-i18n="releaseDate">December 17, 2025</p>
+                        </div>
+                    </div>
+                    <a href="https://distrokid.com/hyperfollow/radek2/folded-galaxies" class="release-box presave-box" target="_blank" rel="noopener">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z"/></svg>
+                        <div class="presave-info">
+                            <p class="presave-label" data-i18n="spotifyPresave">Spotify Pre-save</p>
+                            <p class="presave-cta" data-i18n="presaveCta">Be the first to listen!</p>
+                        </div>
                     </a>
                 </div>
 

--- a/style.css
+++ b/style.css
@@ -190,6 +190,100 @@ body {
     height: 16px;
 }
 
+/* New Release Boxes */
+.new-release-boxes {
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+    flex-wrap: wrap;
+    margin: 1.5rem 0 2rem;
+}
+
+.release-box {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1rem 1.5rem;
+    background: rgba(0, 81, 195, 0.15);
+    border: 1px solid rgba(70, 147, 255, 0.3);
+    border-radius: 8px;
+    text-decoration: none;
+    color: inherit;
+    transition: all 0.3s ease;
+}
+
+.release-box:hover {
+    background: rgba(0, 81, 195, 0.25);
+    border-color: rgba(70, 147, 255, 0.5);
+    transform: translateY(-2px);
+}
+
+.release-cover {
+    width: 60px;
+    height: 60px;
+    border-radius: 4px;
+    object-fit: cover;
+}
+
+.release-info-box {
+    text-align: left;
+}
+
+.release-label {
+    font-family: 'Oswald', sans-serif;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--accent-blue);
+    text-transform: uppercase;
+    letter-spacing: 0.15em;
+    margin-bottom: 0.25rem;
+}
+
+.release-title {
+    font-family: 'Oswald', sans-serif;
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: var(--text-light);
+    margin-bottom: 0.25rem;
+}
+
+.release-date {
+    font-size: 0.875rem;
+    color: var(--text-muted);
+}
+
+.presave-box {
+    background: rgba(29, 185, 84, 0.15);
+    border-color: rgba(29, 185, 84, 0.4);
+}
+
+.presave-box:hover {
+    background: rgba(29, 185, 84, 0.25);
+    border-color: rgba(29, 185, 84, 0.6);
+}
+
+.presave-box svg {
+    color: #1DB954;
+    flex-shrink: 0;
+}
+
+.presave-info {
+    text-align: left;
+}
+
+.presave-label {
+    font-family: 'Oswald', sans-serif;
+    font-size: 1rem;
+    font-weight: 600;
+    color: #1DB954;
+    margin-bottom: 0.25rem;
+}
+
+.presave-cta {
+    font-size: 0.875rem;
+    color: var(--text-muted);
+}
+
 /* Streaming Buttons */
 .streaming-buttons {
     display: flex;

--- a/translations.js
+++ b/translations.js
@@ -20,6 +20,12 @@ const translations = {
         upcomingDesc: "New single arriving soon on all platforms",
         watchTeaser: "Watch the Teaser",
 
+        // New Release - Folded Galaxies
+        newAlbum: "New Album",
+        releaseDate: "December 17, 2025",
+        spotifyPresave: "Spotify Pre-save",
+        presaveCta: "Be the first to listen!",
+
         // History
         theJourney: "The Journey",
 
@@ -85,6 +91,12 @@ const translations = {
         comingSoon: "Již brzy",
         upcomingDesc: "Nový singl brzy na všech platformách",
         watchTeaser: "Sledovat ukázku",
+
+        // New Release - Folded Galaxies
+        newAlbum: "Nové album",
+        releaseDate: "17. prosince 2025",
+        spotifyPresave: "Spotify Pre-save",
+        presaveCta: "Buďte první, kdo uslyší!",
 
         // History
         theJourney: "Příběh",


### PR DESCRIPTION
## Summary
- Added two promotional boxes for the new album "Folded Galaxies" (releasing December 17, 2025)
- New Album box displays cover art and release date
- Spotify Pre-save box links to DistroKid hyperfollow page
- Positioned above Rock Majesty section and below Coming Soon
- Added EN/CZ translations for all new text

## Test plan
- [ ] Verify boxes display correctly on desktop
- [ ] Verify boxes display correctly on mobile
- [ ] Test language switching (EN/CZ)
- [ ] Verify Spotify pre-save link works

🤖 Generated with [Claude Code](https://claude.com/claude-code)