### PR TITLE
Update Folded Galaxies layout and widen Spotify embed

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,8 +103,9 @@
                             <li><span class="event-date">May 1994</span> <span data-i18n="litdEvent2">Golf club</span></li>
                         </ul>
                         <div class="album-note">
+                            <h4 class="album-note-title">Folded Galaxies</h4>
                             <img src="images/history/folded-galaxies-cover.jpg" alt="Folded Galaxies" class="album-note-cover">
-                            <p class="timeline-note" data-i18n="litdNote" data-i18n-html><strong>Folded Galaxies</strong><br>The songs on this album originated as demos recorded in the late 1990s with the band Light in the Darkness. In 2025, I revisited these recordings, rebuilt them from the ground up, and completed them with new lyrics and vocals. Bringing them back felt like opening an old jacket and finding a galaxy hidden in the fold. Deep thanks to Víťa and Michal, who co-created the original demos and kindly agreed to their reuse and transformation into this album.</p>
+                            <p class="timeline-note" data-i18n="litdNote" data-i18n-html>The songs on this album originated as demos recorded in the late 1990s with the band Light in the Darkness. In 2025, I revisited these recordings, rebuilt them from the ground up, and completed them with new lyrics and vocals. Bringing them back felt like opening an old jacket and finding a galaxy hidden in the fold. Deep thanks to Víťa and Michal, who co-created the original demos and kindly agreed to their reuse and transformation into this album.</p>
                         </div>
                         <div class="timeline-media">
                             <a href="https://open.spotify.com/album/4lOjakuL7ywE8u8ZcNCM1V?si=gER1MC42Q_iq5pdVzIX6nA" class="media-link" target="_blank" rel="noopener">

--- a/style.css
+++ b/style.css
@@ -218,7 +218,7 @@ body {
 }
 
 .spotify-embed {
-    max-width: 400px;
+    max-width: 600px;
     margin: 0 auto;
 }
 
@@ -733,22 +733,32 @@ body {
 
 .album-note {
     display: flex;
+    flex-direction: column;
     gap: 1rem;
-    align-items: flex-start;
+    align-items: center;
     margin: 1rem 0;
+    text-align: center;
+}
+
+.album-note-title {
+    font-family: 'Oswald', sans-serif;
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: var(--accent-blue);
+    margin: 0;
 }
 
 .album-note-cover {
-    width: 100px;
-    height: 100px;
-    border-radius: 6px;
+    width: 150px;
+    height: 150px;
+    border-radius: 8px;
     object-fit: cover;
-    flex-shrink: 0;
-    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.3);
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
 }
 
 .album-note .timeline-note {
     margin: 0;
+    text-align: left;
 }
 
 /* Timeline Gallery */

--- a/translations.js
+++ b/translations.js
@@ -33,7 +33,7 @@ const translations = {
         litdDesc: "The beginning of the musical journey. First steps on stage as a guitarist.",
         litdEvent1: "Terč - opening for Memory of Jesus",
         litdEvent2: "Golf club",
-        litdNote: "<strong>Folded Galaxies</strong><br>The songs on this album originated as demos recorded in the late 1990s with the band Light in the Darkness. In 2025, I revisited these recordings, rebuilt them from the ground up, and completed them with new lyrics and vocals. Bringing them back felt like opening an old jacket and finding a galaxy hidden in the fold. Deep thanks to Víťa and Michal, who co-created the original demos and kindly agreed to their reuse and transformation into this album.",
+        litdNote: "The songs on this album originated as demos recorded in the late 1990s with the band Light in the Darkness. In 2025, I revisited these recordings, rebuilt them from the ground up, and completed them with new lyrics and vocals. Bringing them back felt like opening an old jacket and finding a galaxy hidden in the fold. Deep thanks to Víťa and Michal, who co-created the original demos and kindly agreed to their reuse and transformation into this album.",
 
         // Timeline - The Alfa Beat
         alfabeatTitle: "The Alfa Beat",
@@ -105,7 +105,7 @@ const translations = {
         litdDesc: "Začátek hudební cesty. První kroky na pódiu jako kytarista.",
         litdEvent1: "Terč - předkapela Memory of Jesus",
         litdEvent2: "Golf club",
-        litdNote: "<strong>Folded Galaxies</strong><br>Skladby na tomto albu vznikly jako dema nahraná koncem 90. let s kapelou Světlo ve tmě. V roce 2025 jsem se k těmto nahrávkám vrátil, přestavěl je od základů a dokončil s novými texty a vokály. Jejich oživení bylo jako otevřít starou bundu a najít v záhybu ukrytou galaxii. Velké díky Víťovi a Michalovi, kteří se podíleli na původních demech a laskavě souhlasili s jejich použitím a přeměnou v toto album.",
+        litdNote: "Skladby na tomto albu vznikly jako dema nahraná koncem 90. let s kapelou Světlo ve tmě. V roce 2025 jsem se k těmto nahrávkám vrátil, přestavěl je od základů a dokončil s novými texty a vokály. Jejich oživení bylo jako otevřít starou bundu a najít v záhybu ukrytou galaxii. Velké díky Víťovi a Michalovi, kteří se podíleli na původních demech a laskavě souhlasili s jejich použitím a přeměnou v toto album.",
 
         // Timeline - The Alfa Beat
         alfabeatTitle: "The Alfa Beat",


### PR DESCRIPTION
## Summary
- Stack album-note section vertically in timeline (title above image, text below)
- Increase album cover size to 150x150px for better visibility
- Widen Spotify embed from 400px to 600px (50% wider)
- Remove duplicate "Folded Galaxies" title from translations (now as separate HTML element)

## Test plan
- [ ] Verify Folded Galaxies section in timeline shows title > image > text vertically
- [ ] Verify Spotify embed in New Release section is wider
- [ ] Test both EN and CZ translations

🤖 Generated with [Claude Code](https://claude.com/claude-code)