### PR TITLE
Float album cover left with text wrap

### DIFF
--- a/style.css
+++ b/style.css
@@ -732,12 +732,8 @@ body {
 }
 
 .album-note {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    align-items: center;
     margin: 1rem 0;
-    text-align: center;
+    overflow: hidden;
 }
 
 .album-note-title {
@@ -745,20 +741,21 @@ body {
     font-size: 1.25rem;
     font-weight: 600;
     color: var(--accent-blue);
-    margin: 0;
+    margin: 0 0 0.75rem 0;
 }
 
 .album-note-cover {
+    float: left;
     width: 150px;
     height: 150px;
     border-radius: 8px;
     object-fit: cover;
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
+    margin: 0 1rem 0.5rem 0;
 }
 
 .album-note .timeline-note {
     margin: 0;
-    text-align: left;
 }
 
 /* Timeline Gallery */


### PR DESCRIPTION
## Summary
- Change Folded Galaxies album-note section from vertical stacking to float layout
- Picture floats left, text flows around it
- Image size unchanged at 150x150px

## Test plan
- [ ] Verify album cover appears on the left
- [ ] Verify text wraps around the image

🤖 Generated with [Claude Code](https://claude.com/claude-code)