### PR TITLE
Add two-column layout for hero section on desktop

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,58 +30,65 @@
             <div class="hero-content">
                 <h1 class="artist-name">Radek</h1>
 
-                <!-- SECTION 1: Out Now - Folded Galaxies -->
-                <div class="release-section release-section-new">
-                    <div class="section-badge badge-new" data-i18n="newRelease">New Release</div>
-                    <h2 class="section-title">Folded Galaxies</h2>
-                    <p class="section-subtitle" data-i18n="albumLabel">Album</p>
-                    <div class="spotify-embed">
-                        <iframe style="border-radius:12px" src="https://open.spotify.com/embed/album/4lOjakuL7ywE8u8ZcNCM1V?utm_source=generator&theme=0" width="100%" height="352" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
+                <!-- Two-column layout for desktop -->
+                <div class="hero-columns">
+                    <!-- Left Column: New Release -->
+                    <div class="hero-column-left">
+                        <div class="release-section release-section-new">
+                            <div class="section-badge badge-new" data-i18n="newRelease">New Release</div>
+                            <h2 class="section-title">Folded Galaxies</h2>
+                            <p class="section-subtitle" data-i18n="albumLabel">Album</p>
+                            <div class="spotify-embed">
+                                <iframe style="border-radius:12px" src="https://open.spotify.com/embed/album/4lOjakuL7ywE8u8ZcNCM1V?utm_source=generator&theme=0" width="100%" height="500" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
+                            </div>
+                        </div>
                     </div>
-                </div>
 
-                <!-- SECTION 2: Out Now - Rock Majesty -->
-                <div class="release-section release-section-out">
-                    <div class="section-badge badge-out" data-i18n="outNow">Out Now</div>
-                    <h2 class="section-title">Rock Majesty</h2>
-                    <div class="streaming-buttons">
-                    <a href="https://open.spotify.com/track/2WOCaDA9mxoJp5DJkYSJ7k" class="cta-button cta-spotify" target="_blank" rel="noopener">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z"/></svg>
-                        <span data-i18n="ctaSpotify">Spotify</span>
-                    </a>
-                    <a href="https://music.youtube.com/playlist?list=OLAK5uy_lhlQ4HJf0JZCvijq0ViFQPaz4Kxhqda30" class="cta-button cta-ytmusic" target="_blank" rel="noopener">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.376 0 0 5.376 0 12s5.376 12 12 12 12-5.376 12-12S18.624 0 12 0zm0 19.104c-3.924 0-7.104-3.18-7.104-7.104S8.076 4.896 12 4.896s7.104 3.18 7.104 7.104-3.18 7.104-7.104 7.104zm0-13.332c-3.432 0-6.228 2.796-6.228 6.228S8.568 18.228 12 18.228s6.228-2.796 6.228-6.228S15.432 5.772 12 5.772zM9.684 15.54V8.46L15.816 12l-6.132 3.54z"/></svg>
-                        <span data-i18n="ctaYTMusic">YouTube Music</span>
-                    </a>
-                    <a href="https://music.apple.com/cz/album/rock-majesty/1861232781?i=1861232782" class="cta-button cta-apple" target="_blank" rel="noopener">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.546 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.09zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.559-1.701"/></svg>
-                        <span data-i18n="ctaApple">Apple Music</span>
-                    </a>
-                    <a href="https://music.amazon.com/albums/B0G6WC146V?marketplaceId=ATVPDKIKX0DER&musicTerritory=US&trackAsin=B0G6W7JHFS" class="cta-button cta-amazon" target="_blank" rel="noopener">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M13.958 10.09c0 1.232.029 2.256-.591 3.351-.502.891-1.301 1.44-2.186 1.44-1.214 0-1.922-.924-1.922-2.292 0-2.692 2.415-3.182 4.7-3.182v.683zm3.186 7.705c-.209.189-.512.201-.745.074-1.052-.872-1.238-1.276-1.814-2.106-1.734 1.767-2.962 2.297-5.209 2.297-2.66 0-4.731-1.641-4.731-4.925 0-2.565 1.391-4.309 3.37-5.164 1.715-.754 4.11-.891 5.942-1.095v-.41c0-.753.06-1.642-.383-2.294-.385-.579-1.124-.82-1.775-.82-1.205 0-2.277.618-2.54 1.897-.054.285-.261.567-.549.582l-3.061-.333c-.259-.056-.548-.266-.472-.66C6.016 1.313 9.263 0 12.14 0c1.476 0 3.406.392 4.573 1.507 1.476 1.402 1.336 3.278 1.336 5.317v4.812c0 1.446.602 2.08 1.168 2.864.199.276.242.607-.01.811-.632.521-1.754 1.49-2.372 2.035l-.691-.541zM21.63 19.355c-1.527 1.124-3.742 1.722-5.647 1.722-2.675 0-5.082-.987-6.904-2.631-.143-.129-.015-.305.157-.205 1.964 1.143 4.394 1.832 6.904 1.832 1.693 0 3.556-.351 5.27-1.078.258-.111.475.17.22.36zm.629-.716c-.195-.25-1.289-.118-1.781-.06-.149.018-.172-.112-.038-.206.873-.611 2.302-.435 2.469-.23.166.206-.044 1.637-.862 2.32-.126.105-.246.049-.19-.09.184-.458.597-1.484.402-1.734z"/></svg>
-                        <span data-i18n="ctaAmazon">Amazon Music</span>
-                    </a>
-                    <a href="https://link.deezer.com/s/31SDktFK5oSfYBZ91YTNf" class="cta-button cta-deezer" target="_blank" rel="noopener">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M18.81 4.16v3.03H24V4.16h-5.19zM6.27 8.38v3.027h5.189V8.38h-5.19zm12.54 0v3.027H24V8.38h-5.19zM6.27 12.594v3.027h5.189v-3.027h-5.19zm6.271 0v3.027h5.19v-3.027h-5.19zm6.27 0v3.027H24v-3.027h-5.19zM0 16.81v3.029h5.19v-3.03H0zm6.27 0v3.029h5.189v-3.03h-5.19zm6.271 0v3.029h5.19v-3.03h-5.19zm6.27 0v3.029H24v-3.03h-5.19z"/></svg>
-                        <span data-i18n="ctaDeezer">Deezer</span>
-                    </a>
-                    <a href="https://tidal.com/track/481539689/u" class="cta-button cta-tidal" target="_blank" rel="noopener">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M12.012 3.992L8.008 7.996 4.004 3.992 0 7.996 4.004 12l4.004-4.004L12.012 12l-4.004 4.004 4.004 4.004 4.004-4.004L12.012 12l4.004-4.004-4.004-4.004zM16.042 7.996l3.979-3.979L24 7.996l-3.979 3.979z"/></svg>
-                        <span data-i18n="ctaTidal">Tidal</span>
-                    </a>
+                    <!-- Right Column: Out Now + Coming Soon -->
+                    <div class="hero-column-right">
+                        <div class="release-section release-section-out">
+                            <div class="section-badge badge-out" data-i18n="outNow">Out Now</div>
+                            <h2 class="section-title">Rock Majesty</h2>
+                            <div class="streaming-buttons">
+                                <a href="https://open.spotify.com/track/2WOCaDA9mxoJp5DJkYSJ7k" class="cta-button cta-spotify" target="_blank" rel="noopener">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z"/></svg>
+                                    <span data-i18n="ctaSpotify">Spotify</span>
+                                </a>
+                                <a href="https://music.youtube.com/playlist?list=OLAK5uy_lhlQ4HJf0JZCvijq0ViFQPaz4Kxhqda30" class="cta-button cta-ytmusic" target="_blank" rel="noopener">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.376 0 0 5.376 0 12s5.376 12 12 12 12-5.376 12-12S18.624 0 12 0zm0 19.104c-3.924 0-7.104-3.18-7.104-7.104S8.076 4.896 12 4.896s7.104 3.18 7.104 7.104-3.18 7.104-7.104 7.104zm0-13.332c-3.432 0-6.228 2.796-6.228 6.228S8.568 18.228 12 18.228s6.228-2.796 6.228-6.228S15.432 5.772 12 5.772zM9.684 15.54V8.46L15.816 12l-6.132 3.54z"/></svg>
+                                    <span data-i18n="ctaYTMusic">YouTube Music</span>
+                                </a>
+                                <a href="https://music.apple.com/cz/album/rock-majesty/1861232781?i=1861232782" class="cta-button cta-apple" target="_blank" rel="noopener">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.546 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.09zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.559-1.701"/></svg>
+                                    <span data-i18n="ctaApple">Apple Music</span>
+                                </a>
+                                <a href="https://music.amazon.com/albums/B0G6WC146V?marketplaceId=ATVPDKIKX0DER&musicTerritory=US&trackAsin=B0G6W7JHFS" class="cta-button cta-amazon" target="_blank" rel="noopener">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M13.958 10.09c0 1.232.029 2.256-.591 3.351-.502.891-1.301 1.44-2.186 1.44-1.214 0-1.922-.924-1.922-2.292 0-2.692 2.415-3.182 4.7-3.182v.683zm3.186 7.705c-.209.189-.512.201-.745.074-1.052-.872-1.238-1.276-1.814-2.106-1.734 1.767-2.962 2.297-5.209 2.297-2.66 0-4.731-1.641-4.731-4.925 0-2.565 1.391-4.309 3.37-5.164 1.715-.754 4.11-.891 5.942-1.095v-.41c0-.753.06-1.642-.383-2.294-.385-.579-1.124-.82-1.775-.82-1.205 0-2.277.618-2.54 1.897-.054.285-.261.567-.549.582l-3.061-.333c-.259-.056-.548-.266-.472-.66C6.016 1.313 9.263 0 12.14 0c1.476 0 3.406.392 4.573 1.507 1.476 1.402 1.336 3.278 1.336 5.317v4.812c0 1.446.602 2.08 1.168 2.864.199.276.242.607-.01.811-.632.521-1.754 1.49-2.372 2.035l-.691-.541zM21.63 19.355c-1.527 1.124-3.742 1.722-5.647 1.722-2.675 0-5.082-.987-6.904-2.631-.143-.129-.015-.305.157-.205 1.964 1.143 4.394 1.832 6.904 1.832 1.693 0 3.556-.351 5.27-1.078.258-.111.475.17.22.36zm.629-.716c-.195-.25-1.289-.118-1.781-.06-.149.018-.172-.112-.038-.206.873-.611 2.302-.435 2.469-.23.166.206-.044 1.637-.862 2.32-.126.105-.246.049-.19-.09.184-.458.597-1.484.402-1.734z"/></svg>
+                                    <span data-i18n="ctaAmazon">Amazon Music</span>
+                                </a>
+                                <a href="https://link.deezer.com/s/31SDktFK5oSfYBZ91YTNf" class="cta-button cta-deezer" target="_blank" rel="noopener">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M18.81 4.16v3.03H24V4.16h-5.19zM6.27 8.38v3.027h5.189V8.38h-5.19zm12.54 0v3.027H24V8.38h-5.19zM6.27 12.594v3.027h5.189v-3.027h-5.19zm6.271 0v3.027h5.19v-3.027h-5.19zm6.27 0v3.027H24v-3.027h-5.19zM0 16.81v3.029h5.19v-3.03H0zm6.27 0v3.029h5.189v-3.03h-5.19zm6.271 0v3.029h5.19v-3.03h-5.19zm6.27 0v3.029H24v-3.03h-5.19z"/></svg>
+                                    <span data-i18n="ctaDeezer">Deezer</span>
+                                </a>
+                                <a href="https://tidal.com/track/481539689/u" class="cta-button cta-tidal" target="_blank" rel="noopener">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M12.012 3.992L8.008 7.996 4.004 3.992 0 7.996 4.004 12l4.004-4.004L12.012 12l-4.004 4.004 4.004 4.004 4.004-4.004L12.012 12l4.004-4.004-4.004-4.004zM16.042 7.996l3.979-3.979L24 7.996l-3.979 3.979z"/></svg>
+                                    <span data-i18n="ctaTidal">Tidal</span>
+                                </a>
+                            </div>
+                        </div>
+
+                        <!-- SECTION 3: Coming Soon - One Beautiful Day -->
+                        <div class="release-section release-section-soon">
+                            <div class="section-badge badge-soon" data-i18n="comingSoon">Coming Soon</div>
+                            <h2 class="section-title">One Beautiful Day in Litomyšl</h2>
+                            <a href="https://www.instagram.com/s/aGlnaGxpZ2h0OjE4MTA1ODE0NjM5NzMwMTI4?story_media_id=3783426364133660895&igsh=MW5pY3Z3dWtnYTF0dg==" class="teaser-link" target="_blank" rel="noopener">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+                                    <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/>
+                                </svg>
+                                <span data-i18n="watchTeaser">Watch the Teaser</span>
+                            </a>
+                        </div>
                     </div>
-                </div>
-
-                <!-- SECTION 3: Coming Soon - One Beautiful Day -->
-                <div class="release-section release-section-soon">
-                    <div class="section-badge badge-soon" data-i18n="comingSoon">Coming Soon</div>
-                    <h2 class="section-title">One Beautiful Day in Litomyšl</h2>
-                    <a href="https://www.instagram.com/s/aGlnaGxpZ2h0OjE4MTA1ODE0NjM5NzMwMTI4?story_media_id=3783426364133660895&igsh=MW5pY3Z3dWtnYTF0dg==" class="teaser-link" target="_blank" rel="noopener">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
-                            <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163c-3.259 0-3.667.014-4.947.072-4.358.2-6.78 2.618-6.98 6.98-.059 1.281-.073 1.689-.073 4.948 0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98 1.281.058 1.689.072 4.948.072 3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98-1.281-.059-1.69-.073-4.949-.073zm0 5.838c-3.403 0-6.162 2.759-6.162 6.162s2.759 6.163 6.162 6.163 6.162-2.759 6.162-6.163c0-3.403-2.759-6.162-6.162-6.162zm0 10.162c-2.209 0-4-1.79-4-4 0-2.209 1.791-4 4-4s4 1.791 4 4c0 2.21-1.791 4-4 4zm6.406-11.845c-.796 0-1.441.645-1.441 1.44s.645 1.44 1.441 1.44c.795 0 1.439-.645 1.439-1.44s-.644-1.44-1.439-1.44z"/>
-                        </svg>
-                        <span data-i18n="watchTeaser">Watch the Teaser</span>
-                    </a>
                 </div>
             </div>
         </div>

--- a/style.css
+++ b/style.css
@@ -112,7 +112,7 @@ body {
     text-align: center;
     padding: 2rem;
     width: 100%;
-    max-width: 800px;
+    max-width: 1100px;
     margin: 0 auto;
 }
 
@@ -218,8 +218,41 @@ body {
 }
 
 .spotify-embed {
-    max-width: 600px;
+    max-width: 100%;
     margin: 0 auto;
+}
+
+/* Hero Two-Column Layout (Desktop) */
+@media (min-width: 900px) {
+    .hero-columns {
+        display: flex;
+        gap: 2rem;
+        align-items: flex-start;
+        width: 100%;
+    }
+
+    .hero-column-left {
+        flex: 1;
+        min-width: 0;
+    }
+
+    .hero-column-right {
+        flex: 1;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+    }
+
+    .hero-column-left .release-section,
+    .hero-column-right .release-section {
+        margin: 0;
+    }
+
+    .hero-column-right .release-section-out,
+    .hero-column-right .release-section-soon {
+        margin: 0;
+    }
 }
 
 /* Featured Release (Folded Galaxies) */


### PR DESCRIPTION
## Summary
- Desktop: Two-column layout with New Release on left, Out Now + Coming Soon stacked on right
- Left column Spotify embed increased to 500px height (40% taller) to show all songs without scrolling
- Two-column layout activates at 900px breakpoint
- Mobile: Single-column stacked layout preserved
- Hero content area widened to 1100px max-width

## Test plan
- [ ] Verify desktop shows two columns side by side
- [ ] Verify Spotify embed shows all songs without scrolling
- [ ] Verify mobile shows single-column stacked layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)