### PR TITLE
Reduce space above RADEK title by 30%

### DIFF
--- a/style.css
+++ b/style.css
@@ -79,7 +79,7 @@ body {
     align-items: center;
     justify-content: center;
     overflow: visible;
-    padding: 4rem 0 2rem;
+    padding: 2.8rem 0 2rem;
 }
 
 .hero-image {
@@ -894,7 +894,7 @@ footer p {
 @media (max-width: 768px) {
     .hero {
         min-height: auto;
-        padding: 3rem 0 2rem;
+        padding: 2rem 0 2rem;
     }
 
     .hero-content {


### PR DESCRIPTION
## Summary
- Reduce top padding above RADEK title by ~30%
- Desktop: 4rem → 2.8rem
- Mobile: 3rem → 2rem

🤖 Generated with [Claude Code](https://claude.com/claude-code)