### PR TITLE
Align streaming buttons in two columns

### DIFF
--- a/style.css
+++ b/style.css
@@ -445,10 +445,19 @@ body {
 
 /* Streaming Buttons */
 .streaming-buttons {
-    display: flex;
-    gap: 1rem;
-    justify-content: center;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.75rem 1rem;
+    max-width: 400px;
+    margin: 0 auto;
+}
+
+.streaming-buttons .cta-button:nth-child(odd) {
+    justify-self: end;
+}
+
+.streaming-buttons .cta-button:nth-child(even) {
+    justify-self: start;
 }
 
 .cta-button {


### PR DESCRIPTION
## Summary
- Two-column grid layout for streaming buttons
- Left column (Spotify, Apple Music, Deezer) aligned to right edge
- Right column (YouTube Music, Amazon Music, Tidal) aligned to left edge
- Creates clean symmetrical centered layout

## Test plan
- [ ] Verify buttons appear in two columns on desktop
- [ ] Verify left column buttons align right, right column buttons align left
- [ ] Verify mobile still shows icon-only grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)