### PR TITLE
Fix streaming buttons to single line with consistent height

### DIFF
--- a/style.css
+++ b/style.css
@@ -476,6 +476,7 @@ body {
     border-radius: 4px;
     transition: all 0.3s ease;
     box-shadow: 0 4px 20px rgba(0, 81, 195, 0.4);
+    white-space: nowrap;
 }
 
 .cta-button svg {


### PR DESCRIPTION
## Summary
- Add white-space: nowrap to prevent button text from wrapping
- All buttons now display on one line with consistent height

🤖 Generated with [Claude Code](https://claude.com/claude-code)