### PR TITLE
Make iframe wider on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -921,7 +921,7 @@ footer p {
     }
 
     .release-section {
-        padding: 1rem 1.25rem;
+        padding: 1rem 0.75rem;
         margin: 1rem 0;
     }
 


### PR DESCRIPTION
## Summary
- Reduced release-section horizontal padding on mobile (1.25rem → 0.75rem)
- Gives Spotify iframe more width on phone screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)