### PR TITLE
Fix mobile streaming button icon alignment (fixes #59)

### DIFF
--- a/style.css
+++ b/style.css
@@ -946,6 +946,11 @@ footer p {
         margin: 0 auto;
     }
 
+    .streaming-buttons .cta-button:nth-child(odd),
+    .streaming-buttons .cta-button:nth-child(even) {
+        justify-self: center;
+    }
+
     .cta-button {
         padding: 0.875rem;
         font-size: 1rem;


### PR DESCRIPTION
## Summary
Fixes the misaligned streaming button icons on mobile view.

## Problem
On mobile devices, the streaming buttons are displayed as icons only in a 3-column grid. However, the desktop CSS styles had different `justify-self` values for odd buttons (`end`) and even buttons (`start`) to create a centered two-column layout. These styles were still being applied on mobile, causing the icons to appear misaligned instead of being centered in their grid cells.

## Solution
Added a CSS override in the mobile media query (`max-width: 768px`) that sets `justify-self: center` for all streaming button icons, overriding the desktop positioning rules.

## Changes
- `style.css`: Added override rules to center all streaming button icons on mobile

## Testing
- [x] Visual inspection of mobile layout

Fixes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)