### PR TITLE
Add Guitar Rig section with 5 equipment items (fixes #60)

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="style.css?v=19">
+    <link rel="stylesheet" href="style.css?v=20">
 </head>
 <body>
     <div class="lang-toggle">
@@ -92,6 +92,42 @@
                 </div>
             </div>
         </div>
+
+        <section class="gear-section">
+            <h2 class="gear-title" data-i18n="guitarRig">Guitar Rig</h2>
+            <div class="gear-grid">
+                <div class="gear-item">
+                    <div class="gear-image-container">
+                        <img src="images/gear/washburn-n4.jpg" alt="Washburn N4 Natural Matte" class="gear-image" loading="lazy">
+                    </div>
+                    <h3 class="gear-name">Washburn N4 Natural Matte</h3>
+                </div>
+                <div class="gear-item">
+                    <div class="gear-image-container">
+                        <img src="images/gear/fender-telecaster.jpg" alt="Fender Player Telecaster MN 3TS" class="gear-image" loading="lazy">
+                    </div>
+                    <h3 class="gear-name">Fender Player Telecaster MN 3TS</h3>
+                </div>
+                <div class="gear-item">
+                    <div class="gear-image-container">
+                        <img src="images/gear/kemper-player.jpg" alt="Kemper Player" class="gear-image" loading="lazy">
+                    </div>
+                    <h3 class="gear-name">Kemper Player</h3>
+                </div>
+                <div class="gear-item">
+                    <div class="gear-image-container">
+                        <img src="images/gear/evh-5150.jpg" alt="EVH 5150 Iconic" class="gear-image" loading="lazy">
+                    </div>
+                    <h3 class="gear-name">EVH 5150 Iconic</h3>
+                </div>
+                <div class="gear-item">
+                    <div class="gear-image-container">
+                        <img src="images/gear/kemper-kone.jpg" alt="Kemper Kone" class="gear-image" loading="lazy">
+                    </div>
+                    <h3 class="gear-name">Kemper Kone</h3>
+                </div>
+            </div>
+        </section>
 
         <section class="history-section">
             <h2 class="history-title" data-i18n="theJourney">The Journey</h2>

--- a/style.css
+++ b/style.css
@@ -648,6 +648,95 @@ body {
     height: 20px;
 }
 
+/* Guitar Rig Section */
+.gear-section {
+    padding: 4rem 2rem;
+    background: var(--bg-darker);
+    border-top: 1px solid rgba(70, 147, 255, 0.2);
+}
+
+.gear-title {
+    font-family: 'Oswald', sans-serif;
+    font-size: 2.5rem;
+    font-weight: 700;
+    text-align: center;
+    margin-bottom: 3rem;
+    color: var(--text-light);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+}
+
+.gear-grid {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 1.5rem;
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.gear-item {
+    text-align: center;
+    transition: transform 0.3s ease;
+}
+
+.gear-item:hover {
+    transform: translateY(-5px);
+}
+
+.gear-image-container {
+    width: 100%;
+    aspect-ratio: 1;
+    overflow: hidden;
+    border-radius: 8px;
+    border: 1px solid rgba(70, 147, 255, 0.2);
+    background: rgba(10, 10, 10, 0.6);
+    margin-bottom: 1rem;
+}
+
+.gear-image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.3s ease;
+}
+
+.gear-item:hover .gear-image {
+    transform: scale(1.05);
+}
+
+.gear-name {
+    font-family: 'Oswald', sans-serif;
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--text-light);
+    letter-spacing: 0.05em;
+}
+
+@media (max-width: 1024px) {
+    .gear-grid {
+        grid-template-columns: repeat(3, 1fr);
+    }
+}
+
+@media (max-width: 600px) {
+    .gear-section {
+        padding: 3rem 1rem;
+    }
+
+    .gear-title {
+        font-size: 2rem;
+    }
+
+    .gear-grid {
+        grid-template-columns: repeat(2, 1fr);
+        gap: 1rem;
+    }
+
+    .gear-name {
+        font-size: 0.875rem;
+    }
+}
+
 /* History Section */
 .history-section {
     padding: 4rem 2rem;

--- a/translations.js
+++ b/translations.js
@@ -25,6 +25,9 @@ const translations = {
         outNow: "Out Now",
         albumLabel: "Album",
 
+        // Guitar Rig
+        guitarRig: "Guitar Rig",
+
         // History
         theJourney: "The Journey",
 
@@ -96,6 +99,9 @@ const translations = {
         newRelease: "Novinka",
         outNow: "Právě vyšlo",
         albumLabel: "Album",
+
+        // Guitar Rig
+        guitarRig: "Kytarová výbava",
 
         // History
         theJourney: "Příběh",


### PR DESCRIPTION
## Summary
Adds a new "Guitar Rig" section to the website, positioned above "The Journey" section, showcasing the guitar equipment used.

## Problem
The website needed a section to display the guitar rig/equipment as requested in #60.

## Solution
Created a responsive grid-based section displaying 5 pieces of guitar equipment:
1. Washburn N4 Natural Matte
2. Fender Player Telecaster MN 3TS
3. Kemper Player
4. EVH 5150 Iconic
5. Kemper Kone

Each item has an image container and name displayed below.

## Changes
- `index.html`: Added Guitar Rig section HTML with 5 gear items
- `style.css`: Added responsive CSS styles for the gear section
  - 5-column grid on desktop (1200px+)
  - 3-column grid on tablet (600-1024px)
  - 2-column grid on mobile (<600px)
  - Hover effects with subtle scale and lift animations
- `translations.js`: Added EN ("Guitar Rig") and CS ("Kytarová výbava") translations
- Created `images/gear/` directory for equipment images

## Required Images
The following images need to be added to `images/gear/`:
- `washburn-n4.jpg`
- `fender-telecaster.jpg`
- `kemper-player.jpg`
- `evh-5150.jpg`
- `kemper-kone.jpg`

## Testing
- [x] HTML structure verified
- [x] CSS styles added with responsive breakpoints
- [x] Translations added for both languages
- [x] Cache-busting version updated (v19 → v20)

Fixes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)