### PR TITLE
Fix visitor counter width for 3-digit counts

### DIFF
--- a/index.html
+++ b/index.html
@@ -285,8 +285,8 @@
 
         <footer>
             <div class="visits-counter">
-                <object data="https://visitor-badge.laobi.icu/badge?page_id=radek.band" type="image/svg+xml" class="visits-badge" width="74" height="20">
-                    <img src="https://visitor-badge.laobi.icu/badge?page_id=radek.band" alt="Visitor count" width="74" height="20">
+                <object data="https://visitor-badge.laobi.icu/badge?page_id=radek.band" type="image/svg+xml" class="visits-badge" width="82" height="20">
+                    <img src="https://visitor-badge.laobi.icu/badge?page_id=radek.band" alt="Visitor count" width="82" height="20">
                 </object>
             </div>
             <p data-i18n="copyright">&copy; 2025 Radek. All rights reserved.</p>


### PR DESCRIPTION
## Summary
- Increased visitor badge width from 74px to 82px to prevent the counter from being graphically cut off on the right side now that it displays 3 digits

## Test plan
- [ ] Verify the visitor counter displays fully without being clipped
- [ ] Confirm the badge is properly centered in the footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)