### PR TITLE
Fix layout issues in release sections

### DIFF
--- a/style.css
+++ b/style.css
@@ -156,6 +156,8 @@ body {
 .release-section-new {
     background: rgba(29, 185, 84, 0.1);
     border-color: rgba(29, 185, 84, 0.4);
+    padding-left: 1rem;
+    padding-right: 1rem;
 }
 
 .release-section-out {

--- a/style.css
+++ b/style.css
@@ -246,6 +246,7 @@ body {
 }
 
 .spotify-embed {
+    width: 100%;
     max-width: 100%;
     margin: 0 auto;
 }
@@ -293,6 +294,7 @@ body {
         display: flex;
         flex-direction: column;
         justify-content: center;
+        align-items: center;
     }
 }
 


### PR DESCRIPTION
## Summary
- Reduce horizontal padding in New Release section so Spotify embed fills more width
- Add align-items: center to right column sections to prevent teaser link from stretching full width
- Add explicit width: 100% to spotify-embed for consistent sizing

## Test plan
- [ ] Verify Spotify embed in Folded Galaxies section is wider (less green padding on sides)
- [ ] Verify "Watch the Teaser" button is not stretched across the full box
- [ ] Test on Safari and other browsers

🤖 Generated with [Claude Code](https://claude.com/claude-code)