### PR TITLE
Unify Coming Soon section with Out Now styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Radek - Official Artist Page</title>
-    <meta name="description" content="Radek - Original instrumental rock music. Rock Majesty out now, One Beautiful Day in Litomyšl coming soon.">
+    <meta name="description" content="Radek - Original instrumental rock music. Rock Majesty and One Beautiful Day in Litomyšl out now.">
     <meta property="og:title" content="Radek - Official Artist Page">
-    <meta property="og:description" content="Original instrumental rock music. Rock Majesty out now, One Beautiful Day in Litomyšl coming soon.">
+    <meta property="og:description" content="Original instrumental rock music. Rock Majesty and One Beautiful Day in Litomyšl out now.">
     <meta property="og:image" content="images/hero.jpg">
     <meta property="og:type" content="music.song">
     <link rel="icon" type="image/svg+xml" href="favicon.svg?v=3">
@@ -102,9 +102,9 @@
                             </div>
                         </div>
 
-                        <!-- SECTION 3: Coming Soon - One Beautiful Day -->
-                        <div class="release-section release-section-soon">
-                            <div class="section-badge badge-soon" data-i18n="comingSoon">Coming Soon</div>
+                        <!-- SECTION 3: Out Now - One Beautiful Day -->
+                        <div class="release-section release-section-out">
+                            <div class="section-badge badge-out" data-i18n="outNow">Out Now</div>
                             <h2 class="section-title">One Beautiful Day in Litomyšl</h2>
                             <a href="https://www.instagram.com/s/aGlnaGxpZ2h0OjE4MTA1ODE0NjM5NzMwMTI4?story_media_id=3783426364133660895&igsh=MW5pY3Z3dWtnYTF0dg==" class="teaser-link" target="_blank" rel="noopener">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="currentColor">

--- a/style.css
+++ b/style.css
@@ -246,11 +246,6 @@ body {
     border-color: rgba(70, 147, 255, 0.3);
 }
 
-.release-section-soon {
-    background: rgba(100, 100, 100, 0.1);
-    border-color: rgba(150, 150, 150, 0.3);
-}
-
 .release-section-prep {
     background: rgba(255, 153, 0, 0.1);
     border-color: rgba(255, 153, 0, 0.3);
@@ -282,11 +277,6 @@ body {
 .badge-out {
     background: var(--primary-blue);
     color: #fff;
-}
-
-.badge-soon {
-    background: rgba(150, 150, 150, 0.5);
-    color: var(--text-light);
 }
 
 .badge-prep {
@@ -370,7 +360,6 @@ body {
     }
 
     .hero-column-right .release-section-out,
-    .hero-column-right .release-section-soon,
     .hero-column-right .release-section-prep {
         margin: 0;
         flex: 1;

--- a/translations.js
+++ b/translations.js
@@ -2,9 +2,9 @@ const translations = {
     en: {
         // Meta
         pageTitle: "Radek - Official Artist Page",
-        metaDescription: "Radek - Original instrumental rock music. Rock Majesty out now, One Beautiful Day in Litomyšl coming soon.",
+        metaDescription: "Radek - Original instrumental rock music. Rock Majesty and One Beautiful Day in Litomyšl out now.",
         ogTitle: "Radek - Official Artist Page",
-        ogDescription: "Original instrumental rock music. Rock Majesty out now, One Beautiful Day in Litomyšl coming soon.",
+        ogDescription: "Original instrumental rock music. Rock Majesty and One Beautiful Day in Litomyšl out now.",
 
         // Hero
         streamEverywhere: "Listen Everywhere",
@@ -85,9 +85,9 @@ const translations = {
     cs: {
         // Meta
         pageTitle: "Radek - Oficiální stránka umělce",
-        metaDescription: "Radek - Originální instrumentální rocková hudba. Rock Majesty právě vyšlo, One Beautiful Day in Litomyšl již brzy.",
+        metaDescription: "Radek - Originální instrumentální rocková hudba. Rock Majesty a One Beautiful Day in Litomyšl právě vyšlo.",
         ogTitle: "Radek - Oficiální stránka umělce",
-        ogDescription: "Originální instrumentální rocková hudba. Rock Majesty právě vyšlo, One Beautiful Day in Litomyšl již brzy.",
+        ogDescription: "Originální instrumentální rocková hudba. Rock Majesty a One Beautiful Day in Litomyšl právě vyšlo.",
 
         // Hero
         streamEverywhere: "Poslouchej všude",


### PR DESCRIPTION
## Summary
- Change Coming Soon section to use Out Now badge and styling
- Update meta descriptions to reflect both releases are now out
- Remove unused CSS for .badge-soon and .release-section-soon

## Test plan
- [ ] Verify the One Beautiful Day section now shows "Out Now" badge with blue styling
- [ ] Verify meta descriptions are updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)