### PR TITLE
Make streaming icons colorful by default

### DIFF
--- a/style.css
+++ b/style.css
@@ -158,8 +158,7 @@ body {
     color: var(--text-light);
     text-decoration: none;
     transition: all 0.3s ease;
-    background: rgba(255, 255, 255, 0.1);
-    border: 1px solid rgba(255, 255, 255, 0.2);
+    border: 1px solid transparent;
 }
 
 .stream-link:hover {
@@ -171,40 +170,60 @@ body {
     height: 22px;
 }
 
-.stream-spotify:hover {
+.stream-spotify {
     background: #1DB954;
-    border-color: #1DB954;
-    box-shadow: 0 4px 15px rgba(29, 185, 84, 0.5);
+}
+
+.stream-spotify:hover {
+    background: #1ed760;
+    box-shadow: 0 4px 15px rgba(29, 185, 84, 0.6);
+}
+
+.stream-ytmusic {
+    background: #FF0000;
 }
 
 .stream-ytmusic:hover {
-    background: #FF0000;
-    border-color: #FF0000;
-    box-shadow: 0 4px 15px rgba(255, 0, 0, 0.5);
+    background: #ff3333;
+    box-shadow: 0 4px 15px rgba(255, 0, 0, 0.6);
+}
+
+.stream-apple {
+    background: linear-gradient(45deg, #FA233B, #FB5C74);
 }
 
 .stream-apple:hover {
-    background: linear-gradient(45deg, #FA233B, #FB5C74);
-    border-color: #FA233B;
-    box-shadow: 0 4px 15px rgba(250, 35, 59, 0.5);
+    background: linear-gradient(45deg, #FB5C74, #FC8090);
+    box-shadow: 0 4px 15px rgba(250, 35, 59, 0.6);
+}
+
+.stream-amazon {
+    background: #FF9900;
 }
 
 .stream-amazon:hover {
-    background: #FF9900;
-    border-color: #FF9900;
-    box-shadow: 0 4px 15px rgba(255, 153, 0, 0.5);
+    background: #ffad33;
+    box-shadow: 0 4px 15px rgba(255, 153, 0, 0.6);
+}
+
+.stream-deezer {
+    background: #A238FF;
 }
 
 .stream-deezer:hover {
-    background: #A238FF;
-    border-color: #A238FF;
-    box-shadow: 0 4px 15px rgba(162, 56, 255, 0.5);
+    background: #b560ff;
+    box-shadow: 0 4px 15px rgba(162, 56, 255, 0.6);
+}
+
+.stream-tidal {
+    background: #000000;
+    border-color: rgba(255, 255, 255, 0.3);
 }
 
 .stream-tidal:hover {
-    background: #000000;
+    background: #1a1a1a;
     border-color: #ffffff;
-    box-shadow: 0 4px 15px rgba(255, 255, 255, 0.3);
+    box-shadow: 0 4px 15px rgba(255, 255, 255, 0.4);
 }
 
 .song-title {


### PR DESCRIPTION
## Summary
- Each streaming service icon now displays its brand color by default
- Hover effect brightens the color and adds a glow shadow
- Icons retain scale and lift animation on hover

## Test plan
- [ ] Verify all streaming icons show their brand colors (Spotify green, YouTube red, etc.)
- [ ] Verify hover effect brightens the color and adds glow

🤖 Generated with [Claude Code](https://claude.com/claude-code)