### PR TITLE
Add subtitles to release sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,7 @@
                         <div class="release-section release-section-out">
                             <div class="section-badge badge-out" data-i18n="outNow">Out Now</div>
                             <h2 class="section-title">One Beautiful Day in Litomyšl</h2>
+                            <p class="release-subtitle" data-i18n="subtitleOneBeautifulDay">With an enchanting and gorgeous woman.</p>
                             <div class="stream-links">
                                 <span class="stream-link stream-link-disabled" title="Spotify - Coming Soon">
                                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z"/></svg>
@@ -101,6 +102,7 @@
                         <div class="release-section release-section-out">
                             <div class="section-badge badge-out" data-i18n="outNow">Out Now</div>
                             <h2 class="section-title">Rock Majesty</h2>
+                            <p class="release-subtitle" data-i18n="subtitleRockMajesty">A tribute to rock and rock guitar.</p>
                             <div class="stream-links">
                                 <a href="https://open.spotify.com/track/2WOCaDA9mxoJp5DJkYSJ7k" class="stream-link stream-spotify" target="_blank" rel="noopener" title="Spotify">
                                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z"/></svg>

--- a/style.css
+++ b/style.css
@@ -350,6 +350,13 @@ body {
     margin-bottom: 1rem;
 }
 
+.release-subtitle {
+    font-size: 0.9rem;
+    font-style: italic;
+    color: var(--text-muted);
+    margin: 0.25rem 0 0.75rem 0;
+}
+
 .spotify-embed {
     width: 100%;
     max-width: 100%;

--- a/translations.js
+++ b/translations.js
@@ -27,6 +27,8 @@ const translations = {
         albumLabel: "Album",
         preparing: "Preparing",
         prepText: "Radek is playing Extreme",
+        subtitleOneBeautifulDay: "With an enchanting and gorgeous woman.",
+        subtitleRockMajesty: "A tribute to rock and rock guitar.",
 
         // Guitar Rig
         guitarRig: "Guitar Rig",
@@ -110,6 +112,8 @@ const translations = {
         albumLabel: "Album",
         preparing: "Připravuji",
         prepText: "Radek hraje Extreme",
+        subtitleOneBeautifulDay: "S okouzlující a nádhernou ženou.",
+        subtitleRockMajesty: "Pocta rocku a rockové kytaře.",
 
         // Guitar Rig
         guitarRig: "Kytarová výbava",


### PR DESCRIPTION
## Summary
- Add descriptive subtitles between title and streaming icons
- One Beautiful Day: "With an enchanting and gorgeous woman."
- Rock Majesty: "A tribute to rock and rock guitar."
- Add Czech translations for both
- Italic styling for elegant appearance

## Test plan
- [ ] Verify subtitles appear below titles in both sections
- [ ] Test language switching (EN/CS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)