### PR TITLE
Reduce gear section spacing and set Czech as default language

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="cs">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/style.css
+++ b/style.css
@@ -749,7 +749,7 @@ body {
 
 /* Guitar Rig Section */
 .gear-section {
-    padding: 4rem 2rem;
+    padding: 2rem 2rem 4rem;
     background: var(--bg-darker);
     border-top: 1px solid rgba(70, 147, 255, 0.2);
 }

--- a/translations.js
+++ b/translations.js
@@ -176,7 +176,7 @@ function getInitialLanguage() {
     if (urlLang === 'en' || urlLang === 'cs') {
         return urlLang;
     }
-    return localStorage.getItem('lang') || 'en';
+    return localStorage.getItem('lang') || 'cs';
 }
 
 let currentLang = getInitialLanguage();


### PR DESCRIPTION
## Summary
- Reduced top padding of gear section from 4rem to 2rem for tighter layout
- Set Czech (cs) as the default language for visitors without saved preferences
- Updated HTML lang attribute to `cs` to match

## Test plan
- [ ] Verify reduced spacing between timeline and Guitar Rig section
- [ ] Open page in incognito/private mode to confirm Czech is the default
- [ ] Verify language toggle still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)