### PR TITLE
Remove preparing section and align two-column layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Oswald:wght@400;600;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="style.css?v=28">
+    <link rel="stylesheet" href="style.css?v=29">
 </head>
 <body>
     <div class="lang-toggle">
@@ -57,7 +57,7 @@
 
                 <!-- Two-column layout for desktop -->
                 <div class="hero-columns">
-                    <!-- Left Column: Out Now + Preparing -->
+                    <!-- Left Column: Out Now -->
                     <div class="hero-column-left">
                         <!-- SECTION 2: Out Now - One Beautiful Day -->
                         <div class="release-section release-section-out" id="one-beautiful-day">
@@ -111,12 +111,6 @@
                                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M12.012 3.992L8.008 7.996 4.004 3.992 0 7.996 4.004 12l4.004-4.004L12.012 12l-4.004 4.004 4.004 4.004 4.004-4.004L12.012 12l4.004-4.004-4.004-4.004zM16.042 7.996l3.979-3.979L24 7.996l-3.979 3.979z"/></svg>
                                 </a>
                             </div>
-                        </div>
-
-                        <!-- SECTION 4: Preparing -->
-                        <div class="release-section release-section-prep">
-                            <div class="section-badge badge-prep" data-i18n="preparing">Preparing</div>
-                            <a href="#playing-extreme" class="prep-link" data-i18n="prepText">Radek recorded Extreme II for himself</a>
                         </div>
                     </div>
 

--- a/style.css
+++ b/style.css
@@ -314,11 +314,6 @@ body {
     border-color: rgba(70, 147, 255, 0.3);
 }
 
-.release-section-prep {
-    background: rgba(255, 153, 0, 0.1);
-    border-color: rgba(255, 153, 0, 0.3);
-}
-
 .section-badge {
     display: inline-block;
     padding: 0.35rem 1rem;
@@ -345,29 +340,6 @@ body {
 .badge-out {
     background: var(--primary-blue);
     color: #fff;
-}
-
-.badge-prep {
-    background: linear-gradient(135deg, #FF9900, #FFB347);
-    color: #000;
-}
-
-.prep-link {
-    font-size: 1rem;
-    color: var(--text-light);
-    text-decoration: none;
-    transition: color 0.3s ease;
-}
-
-.prep-link:hover {
-    color: #FF9900;
-}
-
-.release-section-prep {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 0.5rem;
 }
 
 .section-title {
@@ -444,8 +416,7 @@ body {
         margin: 0;
     }
 
-    .hero-column-left .release-section-out,
-    .hero-column-left .release-section-prep {
+    .hero-column-left .release-section-out {
         margin: 0;
         flex: 1;
         display: flex;

--- a/translations.js
+++ b/translations.js
@@ -25,8 +25,6 @@ const translations = {
         newRelease: "New Release",
         outNow: "Out Now",
         albumLabel: "Album",
-        preparing: "Preparing",
-        prepText: "Radek recorded Extreme II for himself",
         subtitleOneBeautifulDay: "With an enchanting and gorgeous woman.",
         subtitleRockMajesty: "A tribute to rock music and rock guitar.",
 
@@ -109,8 +107,6 @@ const translations = {
         newRelease: "Novinka",
         outNow: "Právě vyšlo",
         albumLabel: "Album",
-        preparing: "Připravuji",
-        prepText: "Radek si nahrál Extreme II pro sebe",
         subtitleOneBeautifulDay: "S okouzlující a nádhernou ženou.",
         subtitleRockMajesty: "Pocta rockové hudbě a rockové kytaře.",
 


### PR DESCRIPTION
## Summary
- Removed the "Preparing" section from the hero area
- Left column now has two "Out Now" boxes that stretch equally to align with the single "New Release" box in the right column
- Cleaned up associated CSS styles and translation entries

## Test plan
- [ ] Verify the preparing section is no longer visible
- [ ] Check that the two left boxes align nicely with the right box on desktop
- [ ] Verify mobile layout still works correctly
- [ ] Confirm no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)