### PR TITLE
Mark EVH 5150 Iconic as sold in Guitar Rig section

### DIFF
--- a/index.html
+++ b/index.html
@@ -318,8 +318,9 @@
                     </div>
                     <h3 class="gear-name"><a href="https://www.kemper-amps.com/products/cz/profiler-player.html" target="_blank" rel="noopener">Kemper Profile Player</a></h3>
                 </div>
-                <div class="gear-item">
+                <div class="gear-item gear-sold">
                     <div class="gear-image-container">
+                        <span class="gear-sold-badge" data-i18n="gearSold">Sold</span>
                         <a href="https://evhgear.com/gear/amplifiers/combo/5150-iconic-series-40w-1x12-combo/2257100010" target="_blank" rel="noopener">
                             <img src="images/gear/evh-5150.jpg" alt="EVH 5150 Iconic" class="gear-image" loading="lazy">
                         </a>

--- a/style.css
+++ b/style.css
@@ -782,6 +782,42 @@ body {
     letter-spacing: 0.05em;
 }
 
+/* Sold gear styling */
+.gear-sold .gear-image-container {
+    position: relative;
+    border-style: dashed;
+}
+
+.gear-sold .gear-image {
+    filter: grayscale(100%);
+    opacity: 0.6;
+}
+
+.gear-sold:hover .gear-image {
+    transform: none;
+}
+
+.gear-sold-badge {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    z-index: 1;
+    padding: 0.25rem 0.6rem;
+    background: rgba(0, 0, 0, 0.75);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 4px;
+    font-family: 'Oswald', sans-serif;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--text-light);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+}
+
+.gear-sold .gear-name a {
+    opacity: 0.5;
+}
+
 @media (max-width: 1024px) {
     .gear-grid {
         grid-template-columns: repeat(3, 1fr);

--- a/translations.js
+++ b/translations.js
@@ -30,6 +30,7 @@ const translations = {
 
         // Guitar Rig
         guitarRig: "Guitar Rig",
+        gearSold: "Sold",
 
         // History
         theJourney: "The Journey",
@@ -112,6 +113,7 @@ const translations = {
 
         // Guitar Rig
         guitarRig: "Kytarová výbava",
+        gearSold: "Prodáno",
 
         // History
         theJourney: "Příběh",


### PR DESCRIPTION
## Summary
- EVH 5150 Iconic image shown in grayscale with reduced opacity and a dashed border
- "Sold" / "Prodáno" badge displayed in the top-right corner of the image
- Gear name link dimmed to reinforce the inactive status

## Test plan
- [ ] Verify EVH 5150 appears grayscale with "Sold" badge
- [ ] Toggle language and confirm badge shows "Prodáno" in Czech
- [ ] Confirm other gear items are unaffected
- [ ] Check responsive layouts (mobile/tablet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)