### PR TITLE
Move EVH 5150 to a separate Former Gear section

### DIFF
--- a/index.html
+++ b/index.html
@@ -318,15 +318,6 @@
                     </div>
                     <h3 class="gear-name"><a href="https://www.kemper-amps.com/products/cz/profiler-player.html" target="_blank" rel="noopener">Kemper Profile Player</a></h3>
                 </div>
-                <div class="gear-item gear-sold">
-                    <div class="gear-image-container">
-                        <span class="gear-sold-badge" data-i18n="gearSold">Sold</span>
-                        <a href="https://evhgear.com/gear/amplifiers/combo/5150-iconic-series-40w-1x12-combo/2257100010" target="_blank" rel="noopener">
-                            <img src="images/gear/evh-5150.jpg" alt="EVH 5150 Iconic" class="gear-image" loading="lazy">
-                        </a>
-                    </div>
-                    <h3 class="gear-name"><a href="https://evhgear.com/gear/amplifiers/combo/5150-iconic-series-40w-1x12-combo/2257100010" target="_blank" rel="noopener">EVH 5150 Iconic</a></h3>
-                </div>
                 <div class="gear-item">
                     <div class="gear-image-container">
                         <a href="https://www.kemper-amps.com/products/cz/kemper-power-kabinet.html" target="_blank" rel="noopener">
@@ -334,6 +325,17 @@
                         </a>
                     </div>
                     <h3 class="gear-name"><a href="https://www.kemper-amps.com/products/cz/kemper-power-kabinet.html" target="_blank" rel="noopener">Kemper Power Cabinet</a></h3>
+                </div>
+            </div>
+            <h3 class="former-gear-title" data-i18n="formerGear">Former Gear</h3>
+            <div class="former-gear-grid">
+                <div class="gear-item">
+                    <div class="gear-image-container">
+                        <a href="https://evhgear.com/gear/amplifiers/combo/5150-iconic-series-40w-1x12-combo/2257100010" target="_blank" rel="noopener">
+                            <img src="images/gear/evh-5150.jpg" alt="EVH 5150 Iconic" class="gear-image" loading="lazy">
+                        </a>
+                    </div>
+                    <h3 class="gear-name"><a href="https://evhgear.com/gear/amplifiers/combo/5150-iconic-series-40w-1x12-combo/2257100010" target="_blank" rel="noopener">EVH 5150 Iconic</a></h3>
                 </div>
             </div>
         </section>

--- a/style.css
+++ b/style.css
@@ -738,7 +738,7 @@ body {
 
 .gear-grid {
     display: grid;
-    grid-template-columns: repeat(5, 1fr);
+    grid-template-columns: repeat(4, 1fr);
     gap: 1.5rem;
     max-width: 1200px;
     margin: 0 auto;
@@ -782,40 +782,24 @@ body {
     letter-spacing: 0.05em;
 }
 
-/* Sold gear styling */
-.gear-sold .gear-image-container {
-    position: relative;
-    border-style: dashed;
-}
-
-.gear-sold .gear-image {
-    filter: grayscale(100%);
-    opacity: 0.6;
-}
-
-.gear-sold:hover .gear-image {
-    transform: none;
-}
-
-.gear-sold-badge {
-    position: absolute;
-    top: 0.5rem;
-    right: 0.5rem;
-    z-index: 1;
-    padding: 0.25rem 0.6rem;
-    background: rgba(0, 0, 0, 0.75);
-    border: 1px solid rgba(255, 255, 255, 0.2);
-    border-radius: 4px;
+/* Former Gear subsection */
+.former-gear-title {
     font-family: 'Oswald', sans-serif;
-    font-size: 0.75rem;
+    font-size: 1.25rem;
     font-weight: 600;
-    color: var(--text-light);
+    text-align: center;
+    margin: 2.5rem 0 1.5rem;
+    color: rgba(255, 255, 255, 0.5);
     text-transform: uppercase;
     letter-spacing: 0.1em;
 }
 
-.gear-sold .gear-name a {
-    opacity: 0.5;
+.former-gear-grid {
+    display: grid;
+    grid-template-columns: repeat(1, 1fr);
+    gap: 1.5rem;
+    max-width: 240px;
+    margin: 0 auto;
 }
 
 @media (max-width: 1024px) {

--- a/translations.js
+++ b/translations.js
@@ -30,7 +30,7 @@ const translations = {
 
         // Guitar Rig
         guitarRig: "Guitar Rig",
-        gearSold: "Sold",
+        formerGear: "Former Gear",
 
         // History
         theJourney: "The Journey",
@@ -113,7 +113,7 @@ const translations = {
 
         // Guitar Rig
         guitarRig: "Kytarová výbava",
-        gearSold: "Prodáno",
+        formerGear: "Dřívější výbava",
 
         // History
         theJourney: "Příběh",


### PR DESCRIPTION
## Summary
- Moved EVH 5150 Iconic from the main Guitar Rig grid to a new "Former Gear" / "Dřívější výbava" subsection below it
- Removed the grayscale/sold badge styling from PR #119
- Main grid updated from 5 to 4 columns
- Former gear item displays normally with standard hover effects

## Test plan
- [ ] Main rig shows 4 items in a row
- [ ] "Former Gear" heading appears below with EVH 5150 displayed normally
- [ ] Toggle language — heading switches to "Dřívější výbava"
- [ ] Check responsive layouts (tablet/mobile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)