### PR TITLE
Fix former gear item sizing

### DIFF
--- a/style.css
+++ b/style.css
@@ -795,11 +795,12 @@ body {
 }
 
 .former-gear-grid {
-    display: grid;
-    grid-template-columns: repeat(1, 1fr);
-    gap: 1.5rem;
-    max-width: 240px;
-    margin: 0 auto;
+    display: flex;
+    justify-content: center;
+}
+
+.former-gear-grid .gear-item {
+    width: 200px;
 }
 
 @media (max-width: 1024px) {


### PR DESCRIPTION
## Summary
- Fixed oversized EVH 5150 image in the Former Gear section
- Replaced grid layout with flexbox centered layout and fixed 200px item width

## Test plan
- [ ] Former gear item displays at a reasonable size, matching main grid proportions
- [ ] Item remains centered below the "Former Gear" heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)