### PR TITLE
Fix former gear images to display complete items

### DIFF
--- a/style.css
+++ b/style.css
@@ -804,6 +804,10 @@ body {
     width: 200px;
 }
 
+.former-gear-grid .gear-image {
+    object-fit: contain;
+}
+
 @media (max-width: 1024px) {
     .gear-grid {
         grid-template-columns: repeat(3, 1fr);


### PR DESCRIPTION
## Summary
- Changed `object-fit` from `cover` to `contain` for former gear images
- Delta Hořovice (tall portrait) and Digitech RP-1 (wide landscape) now display fully within the square containers
- The dark container background fills any gaps

## Test plan
- [ ] Delta Hořovice shows the complete guitar including headstock and body
- [ ] Digitech RP-1 shows the complete effects processor including all edges
- [ ] Other former gear items (EVH, BOSS, Dave Murray, Washburn) still look good
- [ ] Current rig items remain unaffected (still use `cover`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)