### PR TITLE
Hide visitor counter while keeping it functional

### DIFF
--- a/style.css
+++ b/style.css
@@ -1306,12 +1306,14 @@ footer p {
     color: var(--text-muted);
 }
 
-/* Visits Counter */
+/* Visits Counter - hidden but still counting */
 .visits-counter {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin-bottom: 1rem;
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    opacity: 0;
+    pointer-events: none;
 }
 
 .visits-badge {


### PR DESCRIPTION
## Summary
- Makes the visitor counter invisible using CSS while still loading the badge image
- Visits continue to be tracked without displaying the counter badge

## Test plan
- [ ] Verify the counter badge is not visible on the page
- [ ] Confirm the badge image still loads (check Network tab in dev tools)
- [ ] Verify visit counting still works by checking the badge service

🤖 Generated with [Claude Code](https://claude.com/claude-code)