### PR TITLE
Remove 'New Release' label from Folded Galaxies

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,10 +114,9 @@
                         </div>
                     </div>
 
-                    <!-- Right Column: New Release -->
+                    <!-- Right Column: Featured Release -->
                     <div class="hero-column-right">
-                        <div class="release-section release-section-new">
-                            <div class="section-badge badge-new" data-i18n="newRelease">New Release</div>
+                        <div class="release-section">
                             <h2 class="section-title">Folded Galaxies</h2>
                             <p class="section-subtitle" data-i18n="albumLabel">Album</p>
                             <div class="spotify-embed">


### PR DESCRIPTION
## Summary
- Removes the "New Release" badge from the Folded Galaxies album section
- Updates CSS class from `release-section-new` to `release-section`
- Updates HTML comment to reflect "Featured Release" instead of "New Release"

## Test plan
- [ ] Verify Folded Galaxies section displays correctly without the badge
- [ ] Check styling is consistent with other release sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)