### PR TITLE
Update Folded Galaxies label to Nostalgia EP

### DIFF
--- a/translations.js
+++ b/translations.js
@@ -24,7 +24,7 @@ const translations = {
         // Release Sections
         newRelease: "New Release",
         outNow: "Out Now",
-        albumLabel: "Album",
+        albumLabel: "Nostalgia EP",
         subtitleOneBeautifulDay: "With an enchanting and gorgeous woman.",
         subtitleRockMajesty: "A tribute to rock music and rock guitar.",
 
@@ -111,7 +111,7 @@ const translations = {
         // Release Sections
         newRelease: "Novinka",
         outNow: "Právě vyšlo",
-        albumLabel: "Album",
+        albumLabel: "Vzpomínkové EP",
         subtitleOneBeautifulDay: "S okouzlující a nádhernou ženou.",
         subtitleRockMajesty: "Pocta rockové hudbě a rockové kytaře.",
 


### PR DESCRIPTION
## Summary
- Changes the Folded Galaxies subtitle from the generic "Album" to "Nostalgia EP" (EN) and "Vzpomínkové EP" (CS)
- Better reflects the release as an EP built from late-1990s demos — a memorial/retrospective work

## Test plan
- [ ] Verify English label shows "Nostalgia EP" under the Folded Galaxies heading
- [ ] Switch to Czech and verify label shows "Vzpomínkové EP"

🤖 Generated with [Claude Code](https://claude.com/claude-code)