### PR TITLE
Add session name to Claude Code status line

### DIFF
--- a/.claude/statusline.sh
+++ b/.claude/statusline.sh
@@ -11,6 +11,8 @@ DIR=$(echo "$input" | jq -r '.workspace.current_dir // "?"' | xargs basename)
 ADDED=$(echo "$input" | jq -r '.cost.total_lines_added // 0')
 REMOVED=$(echo "$input" | jq -r '.cost.total_lines_removed // 0')
 DURATION_MS=$(echo "$input" | jq -r '.cost.total_duration_ms // 0')
+SESSION_ID=$(echo "$input" | jq -r '.session_id // ""')
+TRANSCRIPT_PATH=$(echo "$input" | jq -r '.transcript_path // ""')
 
 # Calculate duration in minutes:seconds
 DURATION_SEC=$((DURATION_MS / 1000))
@@ -22,8 +24,20 @@ DURATION="${DURATION_MIN}m${DURATION_SEC_REM}s"
 BRANCH=$(git branch --show-current 2>/dev/null || echo "")
 [ -n "$BRANCH" ] && BRANCH=" $BRANCH |" || BRANCH=""
 
+# Look up session name from sessions-index.json
+SESSION_NAME=""
+if [ -n "$TRANSCRIPT_PATH" ] && [ -n "$SESSION_ID" ]; then
+    SESSIONS_INDEX="$(dirname "$TRANSCRIPT_PATH")/sessions-index.json"
+    if [ -f "$SESSIONS_INDEX" ]; then
+        SESSION_NAME=$(jq -r --arg id "$SESSION_ID" \
+            '.entries[] | select(.sessionId == $id) | .summary // empty' \
+            "$SESSIONS_INDEX" 2>/dev/null)
+    fi
+fi
+[ -n "$SESSION_NAME" ] && SESSION_SEGMENT=" \"${SESSION_NAME}\" |" || SESSION_SEGMENT=""
+
 # Format cost with 2 decimal places
 COST_FMT=$(printf "%.2f" "$COST")
 
 # Output status line
-echo "[$MODEL] $DIR |$BRANCH \$${COST_FMT} | +${ADDED}/-${REMOVED} | ctx:${CTX}% | ${DURATION}"
+echo "[$MODEL] $DIR |$BRANCH${SESSION_SEGMENT} \$${COST_FMT} | +${ADDED}/-${REMOVED} | ctx:${CTX}% | ${DURATION}"


### PR DESCRIPTION
## Summary

- Reads the session name set via `/rename` from `~/.claude/projects/.../sessions-index.json`
- Displays it in the status line between the git branch and cost, e.g. `"session-learning" |`
- Segment is omitted entirely when no session name is set (unnamed sessions)

## Test plan

- [ ] Start Claude Code and run `/rename my-test-session`
- [ ] Trigger a tool use to refresh the status line
- [ ] Verify `"my-test-session"` appears between branch and cost
- [ ] Start a new session without renaming and verify the segment is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)