### PR TITLE
Update gear section links to better sources

### DIFF
--- a/index.html
+++ b/index.html
@@ -298,19 +298,19 @@
             <div class="gear-grid">
                 <div class="gear-item">
                     <div class="gear-image-container">
-                        <a href="https://www.washburn.com/product/n4-nuno-vintage-usa/" target="_blank" rel="noopener">
+                        <a href="https://en.wikipedia.org/wiki/Washburn_N4" target="_blank" rel="noopener">
                             <img src="images/gear/washburn-n4.jpg" alt="Washburn N4-NUNO VINTAGE USA" class="gear-image" loading="lazy">
                         </a>
                     </div>
-                    <h3 class="gear-name"><a href="https://www.washburn.com/product/n4-nuno-vintage-usa/" target="_blank" rel="noopener">Washburn N4-NUNO VINTAGE USA</a></h3>
+                    <h3 class="gear-name"><a href="https://en.wikipedia.org/wiki/Washburn_N4" target="_blank" rel="noopener">Washburn N4-NUNO VINTAGE USA</a></h3>
                 </div>
                 <div class="gear-item">
                     <div class="gear-image-container">
-                        <a href="https://kytary.cz/fender-player-telecaster-mn-3ts/HN191897" target="_blank" rel="noopener">
+                        <a href="https://www.thomann.de/cz/fender_player_ii_tele_mn_3ts.htm" target="_blank" rel="noopener">
                             <img src="images/gear/fender-telecaster.jpg" alt="Fender Player Telecaster MN 3TS" class="gear-image" loading="lazy">
                         </a>
                     </div>
-                    <h3 class="gear-name"><a href="https://kytary.cz/fender-player-telecaster-mn-3ts/HN191897" target="_blank" rel="noopener">Fender Player Telecaster MN 3TS</a></h3>
+                    <h3 class="gear-name"><a href="https://www.thomann.de/cz/fender_player_ii_tele_mn_3ts.htm" target="_blank" rel="noopener">Fender Player Telecaster MN 3TS</a></h3>
                 </div>
                 <div class="gear-item">
                     <div class="gear-image-container">
@@ -383,9 +383,11 @@
                 </div>
                 <div class="gear-item">
                     <div class="gear-image-container">
-                        <img src="images/gear/washburn-n2.jpg" alt="Washburn N2" class="gear-image" loading="lazy">
+                        <a href="https://www.nunoguitars.com/products/n4-colt" target="_blank" rel="noopener">
+                            <img src="images/gear/washburn-n2.jpg" alt="Washburn N2" class="gear-image" loading="lazy">
+                        </a>
                     </div>
-                    <h3 class="gear-name">Washburn N2</h3>
+                    <h3 class="gear-name"><a href="https://www.nunoguitars.com/products/n4-colt" target="_blank" rel="noopener">Washburn N2</a></h3>
                 </div>
                 <div class="gear-item">
                     <div class="gear-image-container">


### PR DESCRIPTION
## Summary

- Replace Washburn N4 link from washburn.com to Wikipedia
- Replace Fender Telecaster link from kytary.cz to Thomann
- Add link to existing Washburn N2 item pointing to nunoguitars.com